### PR TITLE
hot_reload feature instead of bypass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+examples/*/target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ libloading = "0.7"
 bevy = { version = "0.11" }
 
 [features]
-bypass = ["hot_reloading_macros/bypass"]
+hot_reload = ["hot_reloading_macros/hot_reload"]

--- a/README.md
+++ b/README.md
@@ -38,19 +38,23 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
+# This naming scheme with "lib_" prefix is default but can be configured with HotReload::library_name.
 name = "lib_your_app" 
 path = "src/lib.rs"
 crate-type = ["rlib", "dylib"]
 
+[features]
+hot_reload = ["ridiculous_bevy_hot_reloading/hot_reload"]
+
 [dependencies]
-# use "bypass" feature to bypass all hot macros
 ridiculous_bevy_hot_reloading = { git = "https://github.com/DGriffin91/ridiculous_bevy_hot_reloading" } 
 ```
-*This naming scheme with "lib_" prefix is default but can be configured with HotReload::library_name.*
 
+To run with hot reloading:
 
-
-
+```shell
+cargo run --features hot_reload
+```
 
 ## How `#[make_hot]` works
 Given this rotate system as input:

--- a/examples/make_hot_bevy/Cargo.toml
+++ b/examples/make_hot_bevy/Cargo.toml
@@ -11,10 +11,8 @@ path = "src/lib.rs"
 crate-type = ["rlib", "dylib"]
 
 [dependencies]
-bevy = { version = "0.11", features = ["bevy_dylib"] }
-
-# use features = ["bypass"] to bypass all hot macros
-ridiculous_bevy_hot_reloading = { version = "*", path = "../.." } 
+bevy = { version = "0.11", features = ["dynamic_linking"] }
+ridiculous_bevy_hot_reloading = { version = "*", path = "../..", features = ["hot_reload"]}
 
 # Enable max optimizations for dependencies, but not for our code:
 [profile.dev.package."*"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,5 +16,4 @@ proc-macro-crate = "1.2"
 proc-macro = true
 
 [features]
-# Bypass all hot macros
-bypass = []
+hot_reload = []

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,151 +1,157 @@
 extern crate proc_macro;
 
+use proc_macro::TokenStream;
+#[cfg(feature = "hot_reload")]
+use proc_macro2::*;
+#[cfg(feature = "hot_reload")]
+use proc_macro_crate::{crate_name, FoundCrate};
+#[cfg(feature = "hot_reload")]
+use quote::{quote, ToTokens};
+#[cfg(feature = "hot_reload")]
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
 };
-
-use proc_macro::TokenStream;
-use proc_macro2::*;
-use proc_macro_crate::{crate_name, FoundCrate};
+#[cfg(feature = "hot_reload")]
 use syn::{parse_macro_input, FnArg, ItemFn};
-
-use quote::{quote, ToTokens};
 
 #[proc_macro_attribute]
 pub fn make_hot(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    #[cfg(feature = "bypass")]
+    #[cfg(not(feature = "hot_reload"))]
     {
         return item;
     }
 
-    let ast = parse_macro_input!(item as ItemFn);
+    #[cfg(feature = "hot_reload")]
+    {
+        let ast = parse_macro_input!(item as ItemFn);
 
-    let fn_name = &ast.sig.ident;
+        let fn_name = &ast.sig.ident;
 
-    // Try to make unique hash that is appended onto function name
-    // So that there can be multiple functions with the same name
-    // Waiting on https://github.com/rust-lang/rust/issues/54725
-    // For more things to hash like source_file(), etc...
-    let mut hasher = DefaultHasher::new();
-    // An advantage of including the sig here is that it will crash
-    // is the user changes the sig.
-    ast.sig.to_token_stream().to_string().hash(&mut hasher);
-    //format!("{:?}", Span::call_site().unwrap().source_file()).hash(&mut hasher);
-    let hash = hasher.finish();
+        // Try to make unique hash that is appended onto function name
+        // So that there can be multiple functions with the same name
+        // Waiting on https://github.com/rust-lang/rust/issues/54725
+        // For more things to hash like source_file(), etc...
+        let mut hasher = DefaultHasher::new();
+        // An advantage of including the sig here is that it will crash
+        // is the user changes the sig.
+        ast.sig.to_token_stream().to_string().hash(&mut hasher);
+        //format!("{:?}", Span::call_site().unwrap().source_file()).hash(&mut hasher);
+        let hash = hasher.finish();
 
-    let mut args = Vec::new();
-    let mut args_hot_func = Vec::new();
-    let mut arg_names = Vec::new();
-    let mut arg_types = Vec::new();
+        let mut args = Vec::new();
+        let mut args_hot_func = Vec::new();
+        let mut arg_names = Vec::new();
+        let mut arg_types = Vec::new();
 
-    let mut hot_arg_names = Vec::new();
-    let mut hot_arg_types = Vec::new();
+        let mut hot_arg_names = Vec::new();
+        let mut hot_arg_types = Vec::new();
 
-    for arg in &ast.sig.inputs {
-        args.push(arg.clone());
-        args_hot_func.push(arg.clone());
-        match arg {
-            FnArg::Receiver(_) => (),
-            FnArg::Typed(pt) => {
-                let mut pt = pt.clone();
-                match *pt.pat {
-                    syn::Pat::Ident(ref mut id) => {
-                        arg_names.push(id.ident.clone());
-                        let name = id.ident.clone();
-                        hot_arg_names.push(quote! { #name });
-                    }
-                    _ => (),
-                }
-                arg_types.push(pt.ty.clone())
-            }
-        }
-    }
-
-    // Below deals with converting `mut commands: Commands` to `commands: &mut Commands`
-    for (idx, arg) in args_hot_func.iter_mut().enumerate() {
-        match arg.clone() {
-            FnArg::Receiver(_) => (),
-            FnArg::Typed(a) => match &*a.ty {
-                syn::Type::Path(p) => {
-                    if p.path.segments.len() == 1 {
-                        if p.path.segments[0].ident == "Commands" {
-                            let name = &mut hot_arg_names[idx];
-                            let tok: TokenStream = quote! { #name : &mut Commands }.into();
-                            *arg = parse_macro_input!(tok as FnArg);
-                            *name = quote! {&mut #name};
-                            break;
+        for arg in &ast.sig.inputs {
+            args.push(arg.clone());
+            args_hot_func.push(arg.clone());
+            match arg {
+                FnArg::Receiver(_) => (),
+                FnArg::Typed(pt) => {
+                    let mut pt = pt.clone();
+                    match *pt.pat {
+                        syn::Pat::Ident(ref mut id) => {
+                            arg_names.push(id.ident.clone());
+                            let name = id.ident.clone();
+                            hot_arg_names.push(quote! { #name });
                         }
-                    } else {
-                        continue;
+                        _ => (),
                     }
-                }
-                _ => continue,
-            },
-        }
-    }
-
-    for arg in &args_hot_func {
-        match arg {
-            FnArg::Receiver(_) => (),
-            FnArg::Typed(a) => hot_arg_types.push(a.ty.clone()),
-        }
-    }
-
-    let generics = &ast.sig.generics;
-    let where_clause = &ast.sig.generics.where_clause;
-    let fn_token = &ast.sig.fn_token;
-    let vis = &ast.vis;
-
-    let return_type = ast.sig.output;
-
-    let fn_name_orig_code_str = &format!("ridiculous_bevy_hot_{}_{}", fn_name, hash);
-
-    let fn_name_orig_code = &Ident::new(fn_name_orig_code_str, Span::call_site());
-
-    let orig_stmts = ast.block.stmts;
-
-    let orig_func = quote! {
-        #[no_mangle] //#[allow(unused_mut)]
-        #vis #fn_token #fn_name_orig_code #generics( #(#args_hot_func),*) #return_type #where_clause {
-            #(#orig_stmts)*
-        }
-    };
-
-    let found_crate = crate_name("ridiculous_bevy_hot_reloading")
-        .expect("ridiculous_bevy_hot_reloading is present in `Cargo.toml`");
-
-    let crate_found = match found_crate {
-        FoundCrate::Itself => quote!(crate),
-        FoundCrate::Name(name) => {
-            let ident = Ident::new(&name, Span::call_site());
-            quote!( #ident)
-        }
-    };
-
-    let dyn_func = quote! {
-        #[allow(unused_mut)] // added because rust analyzer will complain about the mut on `mut query: Query<`
-        #vis #fn_token #fn_name #generics( #(#args),*,
-        hot_reload_lib_internal_use_only: Res<ridiculous_bevy_hot_reloading::HotReloadLibInternalUseOnly>) #return_type #where_clause {
-            if let Some(lib) = &hot_reload_lib_internal_use_only.library {
-                unsafe {
-                    let func: #crate_found::libloading::Symbol<unsafe extern "C" fn (#(#hot_arg_types),*) #return_type , > =
-                        lib.get(#fn_name_orig_code_str.as_bytes()).unwrap_or_else(|_| {
-                            panic!(
-                                "Can't find required function {}",
-                                #fn_name_orig_code_str
-                            )
-                        });
-                    return func(#(#hot_arg_names),*);
+                    arg_types.push(pt.ty.clone())
                 }
             }
-            panic!("Hot reload library is None");
-            //return #fn_name_orig_code(#(#hot_arg_names),*);
         }
-    };
 
-    TokenStream::from(quote! {
-        #orig_func
-        #dyn_func
-    })
+        // Below deals with converting `mut commands: Commands` to `commands: &mut Commands`
+        for (idx, arg) in args_hot_func.iter_mut().enumerate() {
+            match arg.clone() {
+                FnArg::Receiver(_) => (),
+                FnArg::Typed(a) => match &*a.ty {
+                    syn::Type::Path(p) => {
+                        if p.path.segments.len() == 1 {
+                            if p.path.segments[0].ident == "Commands" {
+                                let name = &mut hot_arg_names[idx];
+                                let tok: TokenStream = quote! { #name : &mut Commands }.into();
+                                *arg = parse_macro_input!(tok as FnArg);
+                                *name = quote! {&mut #name};
+                                break;
+                            }
+                        } else {
+                            continue;
+                        }
+                    }
+                    _ => continue,
+                },
+            }
+        }
+
+        for arg in &args_hot_func {
+            match arg {
+                FnArg::Receiver(_) => (),
+                FnArg::Typed(a) => hot_arg_types.push(a.ty.clone()),
+            }
+        }
+
+        let generics = &ast.sig.generics;
+        let where_clause = &ast.sig.generics.where_clause;
+        let fn_token = &ast.sig.fn_token;
+        let vis = &ast.vis;
+
+        let return_type = ast.sig.output;
+
+        let fn_name_orig_code_str = &format!("ridiculous_bevy_hot_{}_{}", fn_name, hash);
+
+        let fn_name_orig_code = &Ident::new(fn_name_orig_code_str, Span::call_site());
+
+        let orig_stmts = ast.block.stmts;
+
+        let orig_func = quote! {
+            #[no_mangle] //#[allow(unused_mut)]
+            #vis #fn_token #fn_name_orig_code #generics( #(#args_hot_func),*) #return_type #where_clause {
+                #(#orig_stmts)*
+            }
+        };
+
+        let found_crate = crate_name("ridiculous_bevy_hot_reloading")
+            .expect("ridiculous_bevy_hot_reloading is present in `Cargo.toml`");
+
+        let crate_found = match found_crate {
+            FoundCrate::Itself => quote!(crate),
+            FoundCrate::Name(name) => {
+                let ident = Ident::new(&name, Span::call_site());
+                quote!( #ident)
+            }
+        };
+
+        let dyn_func = quote! {
+            #[allow(unused_mut)] // added because rust analyzer will complain about the mut on `mut query: Query<`
+            #vis #fn_token #fn_name #generics( #(#args),*,
+            hot_reload_lib_internal_use_only: Res<ridiculous_bevy_hot_reloading::HotReloadLibInternalUseOnly>) #return_type #where_clause {
+                if let Some(lib) = &hot_reload_lib_internal_use_only.library {
+                    unsafe {
+                        let func: #crate_found::libloading::Symbol<unsafe extern "C" fn (#(#hot_arg_types),*) #return_type , > =
+                            lib.get(#fn_name_orig_code_str.as_bytes()).unwrap_or_else(|_| {
+                                panic!(
+                                    "Can't find required function {}",
+                                    #fn_name_orig_code_str
+                                )
+                            });
+                        return func(#(#hot_arg_names),*);
+                    }
+                }
+                panic!("Hot reload library is None");
+                //return #fn_name_orig_code(#(#hot_arg_names),*);
+            }
+        };
+
+        TokenStream::from(quote! {
+            #orig_func
+            #dyn_func
+        })
+    }
 }


### PR DESCRIPTION
I like my projects to run in their "default/normal" state when they are built with bare `cargo build --release` etc. instead of having to remember to disable dev related features to make a build. This wasn't possible with how the bypass feature worked.

This PR replaces `bypass` with a non-default `hot_reload` feature to enable hot reloading. Makes it opt in instead of opt out. With this PR you run with `cargo run --hot_reload` to have it do hot reloading. 

I think this is more "proper" use of Rust features, which are supposed to be "additive":
> A consequence of this is that features should be additive. That is, enabling a feature should not disable functionality, and it should usually be safe to enable any combination of features.
https://doc.rust-lang.org/cargo/reference/features.html#feature-unification

I totally understand if you aren't interested in having it work this way though. I'm happy to just use my own fork, just thought I'd share in case you liked it better as well.