### PR TITLE
Option to use file polling with cargo watch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,5 +310,8 @@ fn is_wsl() -> bool {
 /// Test if the program is running under WSL
 #[cfg(not(target_os = "linux"))]
 fn is_wsl() -> bool {
+    if let Ok(dir) = std::env::current_dir() {
+        return dir.to_string_lossy().starts_with("\\\\wsl");
+    }
     false
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,15 +90,15 @@ impl Plugin for HotReloadPlugin {
 
         if self.auto_watch {
             let build_cmd = format!(
-                    "build --lib --target-dir {} {} {} --features ridiculous_bevy_hot_reloading/hot_reload",
-                    library_paths.folder.parent().unwrap().to_string_lossy(),
-                    if release_mode { "--release" } else { "" },
-                    if self.bevy_dylib {
-                        "--features bevy/dynamic_linking"
-                    } else {
-                        ""
-                    },
-                );
+                "build --lib --target-dir {} {} {} --features ridiculous_bevy_hot_reloading/hot_reload",
+                library_paths.folder.parent().unwrap().to_string_lossy(),
+                if release_mode { "--release" } else { "" },
+                if self.bevy_dylib {
+                    "--features bevy/dynamic_linking"
+                } else {
+                    ""
+                },
+            );
             child = Some(ChildGuard({
                 let mut command = std::process::Command::new("cargo");
                 command


### PR DESCRIPTION
Cargo watch has a --poll flag that is useful in situations where you can't rely on filesystem events being consistent. This PR exposes that flag as a field on HotReloadPlugin.

This is especially useful when using WSL as you might be modifying the files in Windows and running in WSL or vice versa and WSL sadly doesn't send the file events between the two systems. I added some simple WSL detection to enable polling by default for those cases.

I also made a slight change to the feature cfg for build() to reduce some indentation that I added in my previous PR.